### PR TITLE
Performance: order_dir_entry: avoid calls to path() and to_str

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,7 @@ fn path_to_str(dir: &Path) -> &str {
 }
 
 fn order_dir_entry(a: &DirEntry, b: &DirEntry) -> Ordering {
-    let (a_path, b_path) = (a.path(), b.path());
-    let a_str = a_path.to_str().unwrap_or("");
-    let b_str = b_path.to_str().unwrap_or("");
-
-    a_str.cmp(b_str)
+    a.file_name().cmp(&b.file_name())
 }
 
 fn get_sorted_dir_entries(path: &Path) -> io::Result<Vec<DirEntry>> {


### PR DESCRIPTION
We can sort based on the file name instead of the full path, as we are only ever comparing entries in the same directory.

Instead of converting the filenames (OSString) to str's, we use the Ordering on OSString directly