### PR TITLE
Performance improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,18 +113,6 @@ fn is_hidden_file_name(file_name: &str) -> bool {
     file_name != "." && file_name != ".." && file_name.starts_with(".")
 }
 
-fn is_hidden_path(dir: &Path) -> bool {
-    dir.components()
-        .last()
-        .and_then(|x| {
-            let str = x.as_ref()
-                .to_str()
-                .unwrap_or("");
-            Some(is_hidden_file_name(str))
-        })
-        .unwrap_or(false)
-}
-
 fn iterate_folders(path: &Path,
                    levels: &mut Vec<bool>,
                    t: &mut TerminalType,
@@ -132,7 +120,7 @@ fn iterate_folders(path: &Path,
                    prefix_buffer: &mut String)
                    -> io::Result<()> {
     let file_name = path_to_str(path);
-    if !config.show_hidden && is_hidden_path(path) {
+    if !config.show_hidden && is_hidden_file_name(file_name) {
         return Ok(());
     }
 


### PR DESCRIPTION
This seems to be a nice improvement - 1.2s -> 0.94s.

# Before:

target/release/tree-rs
======================
('  ', 1.2048170566558838)
('  ', 1.2659578323364258)
('  ', 1.216926097869873)
('  ', 1.2179558277130127)
('  ', 1.2108631134033203)
('  ', 1.1955699920654297)
('  ', 1.193965196609497)

avg: 1.20922641754, min: 1.19556999207, max: 1.21795582771, total: 6.04613208771
()

tree
====
('  ', 1.63966703414917)
('  ', 1.6429088115692139)
('  ', 1.6390910148620605)
('  ', 1.6406300067901611)
('  ', 1.6823318004608154)
('  ', 1.6558310985565186)
('  ', 1.6473350524902344)

avg: 1.64527440071, min: 1.63966703415, max: 1.65583109856, total: 8.22637200356

('Perf tree-rs/tree:', 0.7349694476610691)
('Benchmarking finished in ', 23.881664037704468)

# After

target/release/tree-rs
======================
('  ', 0.9552710056304932)
('  ', 0.9367918968200684)
('  ', 0.9414410591125488)
('  ', 0.936661958694458)
('  ', 0.9443230628967285)
('  ', 0.9513859748840332)
('  ', 0.938974142074585)

avg: 0.942583227158, min: 0.93679189682, max: 0.951385974884, total: 4.71291613579
()

tree
====
('  ', 1.6670989990234375)
('  ', 1.6833899021148682)
('  ', 1.6772921085357666)
('  ', 1.6681950092315674)
('  ', 1.6716859340667725)
('  ', 1.66109299659729)
('  ', 1.6731929779052734)

avg: 1.67149300575, min: 1.66709899902, max: 1.67729210854, total: 8.35746502876

('Perf tree-rs/tree:', 0.5639169436627164)
('Benchmarking finished in ', 22.139941930770874)