### PR TITLE
feat: add support for `-I`

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,26 +1,12 @@
-use std::collections::VecDeque;
-
 use crate::pathiterator::{FileIterator, IteratorItem};
 
 pub struct FilteredIterator {
     pub source: FileIterator,
-    cache: VecDeque<IteratorItem>,
-    skip: bool,
-    next_item: Option<IteratorItem>,
 }
 
 impl FilteredIterator {
     pub fn new(iterator: FileIterator) -> Self {
-        FilteredIterator {
-            source: iterator,
-            cache: VecDeque::new(),
-            skip: false,
-            next_item: None,
-        }
-    }
-
-    pub fn skip_filter(&mut self) {
-        self.skip = true;
+        FilteredIterator { source: iterator }
     }
 }
 
@@ -28,32 +14,6 @@ impl Iterator for FilteredIterator {
     type Item = IteratorItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.skip {
-            return self.source.next();
-        }
-
-        if let Some(cache_item) = self.cache.pop_front() {
-            return Some(cache_item);
-        }
-
-        if let Some(next_item) = self.next_item.take() {
-            return Some(next_item);
-        }
-
-        for item in self.source.by_ref() {
-            if item.is_dir() {
-                self.cache.push_back(item);
-            } else {
-                // If the cache already contains a folder, 
-                // start emptying cache, and save the item.
-                if let Some(cache_front) = self.cache.pop_front() {
-                    self.next_item = Some(item);
-                    return Some(cache_front);
-                }
-                return Some(item);
-            }
-        }
-
-        None
+        self.source.next()
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -22,17 +22,6 @@ impl FilteredIterator {
     pub fn skip_filter(&mut self) {
         self.skip = true;
     }
-
-    /// Remove previous directories from cache that shouldn't be
-    /// shown because they are empty.
-    fn remove_empty_directories_from_cache(&mut self, item: &IteratorItem) {
-        while let Some(last) = self.cache.pop_back() {
-            if last.level < item.level {
-                self.cache.push_back(last);
-                break;
-            }
-        }
-    }
 }
 
 impl Iterator for FilteredIterator {
@@ -51,14 +40,12 @@ impl Iterator for FilteredIterator {
             return Some(next_item);
         }
 
-        while let Some(item) = self.source.next() {
-            self.remove_empty_directories_from_cache(&item);
-
+        for item in self.source.by_ref() {
             if item.is_dir() {
                 self.cache.push_back(item);
             } else {
-                // If the cache already contains a folder, start emptying cache, and
-                // save the item.
+                // If the cache already contains a folder, 
+                // start emptying cache, and save the item.
                 if let Some(cache_front) = self.cache.pop_front() {
                     self.next_item = Some(item);
                     return Some(cache_front);

--- a/src/pathiterator.rs
+++ b/src/pathiterator.rs
@@ -119,15 +119,12 @@ impl Iterator for FileIterator {
     type Item = IteratorItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(item) = self.queue.pop_back() {
+        self.queue.pop_back().map(|item| {
             if item.is_dir() && item.level < self.config.max_level {
-                // println!("{:?}", item.file_name);
                 self.push_dir(&item);
             }
 
-            Some(item)
-        } else {
-            None
-        }
+            item
+        })
     }
 }

--- a/src/tests/test_simple.rs
+++ b/src/tests/test_simple.rs
@@ -64,18 +64,51 @@ fn test_max_depth() {
 fn test_filter_txt_files() {
     let expected = r#"simple
 └── yyy
+    ├── k
+    ├── s
     ├── test.txt
+    └── zz
+        └── a
+            └── b
 "#;
 
     let (output, summary) = run_cmd(
         Path::new("tests/simple"),
         Config {
-            include_glob: Some(Glob::new("*.txt").unwrap().compile_matcher()),
+            include_globs: vec![Glob::new("*.txt").unwrap().compile_matcher()],
             ..Default::default()
         },
     );
-    assert_eq!(1, summary.num_folders);
+    assert_eq!(6, summary.num_folders);
     assert_eq!(1, summary.num_files);
+
+    assert_eq!(expected, output);
+}
+
+#[test]
+fn test_exclude_txt_files() {
+    let expected = r#"simple
+└── yyy
+    ├── k
+    ├── s
+    │   ├── a
+    │   └── t
+    └── zz
+        └── a
+            └── b
+                └── c
+"#;
+
+    let (output, summary) = run_cmd(
+        Path::new("tests/simple"),
+        Config {
+            exlude_globs: vec![Glob::new("*.txt").unwrap().compile_matcher()],
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(6, summary.num_folders);
+    assert_eq!(3, summary.num_files);
 
     assert_eq!(expected, output);
 }

--- a/src/tests/test_simple.rs
+++ b/src/tests/test_simple.rs
@@ -79,6 +79,7 @@ fn test_filter_txt_files() {
             ..Default::default()
         },
     );
+
     assert_eq!(6, summary.num_folders);
     assert_eq!(1, summary.num_files);
 
@@ -109,7 +110,6 @@ fn test_exclude_txt_files() {
 
     assert_eq!(6, summary.num_folders);
     assert_eq!(3, summary.num_files);
-
     assert_eq!(expected, output);
 }
 

--- a/src/tree_printer.rs
+++ b/src/tree_printer.rs
@@ -118,7 +118,8 @@ pub struct Config {
     pub show_hidden: bool,
     pub show_only_dirs: bool,
     pub max_level: usize,
-    pub include_glob: Option<GlobMatcher>,
+    pub include_globs: Vec<GlobMatcher>,
+    pub exlude_globs: Vec<GlobMatcher>,
 }
 
 impl Default for Config {
@@ -128,7 +129,8 @@ impl Default for Config {
             show_hidden: false,
             show_only_dirs: false,
             max_level: usize::MAX,
-            include_glob: None,
+            include_globs: Vec::new(),
+            exlude_globs: Vec::new(),
         }
     }
 }
@@ -164,7 +166,8 @@ impl<'a, T: Terminal<Output = W>, W: std::io::Write> TreePrinter<'a, T, W> {
 
     fn get_iterator(&self, path: &Path) -> filter::FilteredIterator {
         let config = pathiterator::FileIteratorConfig {
-            include_glob: self.config.include_glob.clone(),
+            include_globs: self.config.include_globs.clone(),
+            exlude_globs: self.config.exlude_globs.clone(),
             max_level: self.config.max_level,
             show_hidden: self.config.show_hidden,
             show_only_dirs: self.config.show_only_dirs,
@@ -172,7 +175,7 @@ impl<'a, T: Terminal<Output = W>, W: std::io::Write> TreePrinter<'a, T, W> {
 
         let list = pathiterator::FileIterator::new(path, config);
         let mut list = filter::FilteredIterator::new(list);
-        if self.config.include_glob.is_none() {
+        if self.config.include_globs.is_empty() && self.config.exlude_globs.is_empty() {
             list.skip_filter();
         }
 

--- a/src/tree_printer.rs
+++ b/src/tree_printer.rs
@@ -173,13 +173,8 @@ impl<'a, T: Terminal<Output = W>, W: std::io::Write> TreePrinter<'a, T, W> {
             show_only_dirs: self.config.show_only_dirs,
         };
 
-        let list = pathiterator::FileIterator::new(path, config);
-        let mut list = filter::FilteredIterator::new(list);
-        if self.config.include_globs.is_empty() && self.config.exlude_globs.is_empty() {
-            list.skip_filter();
-        }
-
-        list
+        let iterator = pathiterator::FileIterator::new(path, config);
+        filter::FilteredIterator::new(iterator)
     }
 
     /// # Errors


### PR DESCRIPTION
- also add test case
- remove `fn remove_empty_directories_from_cache` as `tree` command displays empty directories
- doing the above fixed another test case
- change type of CLI parameter for `-P` from `Option<String>` to `Vec<String>` to be in accordance with `tree` command
- fix expected result test `test_filter_txt_files`

TODO:
Test `test_filter_txt_files` still breaks. The `expected` value is based on `tree`'s output, therefore it's correct. The logic in this crate needs to be validated and corrected.