### PR TITLE
chore: add coverage badge and flag comparison

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,104 @@
+# tree-rs Feature Comparison with Original `tree` Command
+
+---
+
+## Supported options
+
+| Flag | Supported |
+|------|-----------|
+| `-a`, `--all` | ✅ |
+| `-d` | ✅ |
+| `-l` | ❌ |
+| `-f` | ❌ |
+| `-x` | ❌ |
+| `-L <level>`, `--level` | ✅ |
+| `-R` | ❌ |
+| `-P <pattern>` | ✅ |
+| `-I <pattern>` | ✅ |
+| `--gitignore` | ❌ |
+| `--gitfile` | ❌ |
+| `--ignore-case` | ❌ |
+| `--matchdirs` | ❌ |
+| `--metafirst` | ❌ |
+| `--prune` | ❌ |
+| `--info` | ❌ |
+| `--infofile` | ❌ |
+| `--noreport` | ❌ |
+| `--charset` | ❌ |
+| `--filelimit` | ❌ |
+| `--timefmt` | ❌ |
+| `-o <filename>` | ❌ |
+| `-q` | ❌ |
+| `-N` | ❌ |
+| `-Q` | ❌ |
+| `-p` | ❌ |
+| `-u` | ❌ |
+| `-g` | ❌ |
+| `-s` | ❌ |
+| `-h` | ❌ |
+| `--si` | ❌ |
+| `--du` | ❌ |
+| `-D` | ❌ |
+| `-F` | ❌ |
+| `--inodes` | ❌ |
+| `--device` | ❌ |
+| `-v` | ❌ |
+| `-t` | ❌ |
+| `-c` | ❌ |
+| `-U` | ❌ |
+| `-r` | ❌ |
+| `--dirsfirst` | ❌ |
+| `--filesfirst` | ❌ |
+| `--sort` | ❌ |
+| `-i` | ❌ |
+| `-A` | ❌ |
+| `-S` | ❌ |
+| `-n` | ✅ |
+| `-C` | ✅ |
+| `-X` | ❌ |
+| `-J` | ❌ |
+| `-H <baseHREF>` | ❌ |
+| `-T <title>` | ❌ |
+| `--nolinks` | ❌ |
+| `--hintro` | ❌ |
+| `--houtro` | ❌ |
+| `--hyperlink` | ❌ |
+| `--scheme` | ❌ |
+| `--authority` | ❌ |
+| `--fromfile` | ❌ |
+| `--fromtabfile` | ❌ |
+| `--fflinks` | ❌ |
+| `--opt-toggle` | ❌ |
+| `--help` | ✅ |
+| `--version` | ✅ |
+| `--` | ❌ |
+
+---
+
+## Environment Variables
+
+| Variable | Supported |
+|----------|-----------|
+| `LS_COLORS` | ❌ |
+| `TREE_COLORS` | ❌ |
+| `CLICOLOR` | ❌ |
+| `CLICOLOR_FORCE` | ❌ |
+| `NO_COLOR` | ❌ |
+| `LC_CTYPE` | ❌ |
+| `LC_TIME` | ❌ |
+| `TZ` | ❌ |
+
+---
+
+## Special Files
+
+| Feature | Supported |
+|---------|-----------|
+| `.gitignore` | ❌ |
+| `.info` files | ❌ |
+| `/etc/DIR_COLORS` | ❌ |
+| `~/.dircolors` | ❌ |
+
+---
+
+*Comparison based on tree v2.2.1 and tree-rs v0.6.4 (2025-10-04)*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Crates.io](https://img.shields.io/crates/v/tree-rs.svg)](https://crates.io/crates/tree-rs)
 [![Rust CI](https://github.com/sighol/tree-rs/actions/workflows/rust-ci.yaml/badge.svg)](https://github.com/sighol/tree-rs/actions/workflows/rust-ci.yaml)
+[![Coverage](https://img.shields.io/badge/coverage-96%25-brightgreen)](https://github.com/sighol/tree-rs)
 
 # Tree-rs
 
@@ -29,3 +30,7 @@ cargo install tree-rs
 # or
 cargo install --git https://github.com/sighol/tree-rs
 ```
+
+## How close to actual `tree`?
+
+See [progress](PROGRESS.md) for a detailed comparison with the original `tree` command.


### PR DESCRIPTION
- Add a static badge showing 96% coverage
- Add `PROGRESS.md` showing what features of the original `tree` command have been ported.